### PR TITLE
Removed TechSmithAddScriptKey processor from SnagIt pkg recipe #1

### DIFF
--- a/TechSmithSnagit/TechSmithSnagit.pkg.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.pkg.recipe
@@ -21,15 +21,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>TechSmithAddScriptKey</string>
-            <key>Arguments</key>
-            <dict>
-                <key>REG_KEY</key>
-                <string>%SNAGIT_KEY%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>AppDmgVersioner</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Looks like this step won't work since you removed the postinstall script. The pkg recipe runs without it; is it needed now?
