### PR TITLE
Missing escaped space in path defining ver

### DIFF
--- a/TechSmithCamtasia/TechSmithCamtasia.munki.recipe
+++ b/TechSmithCamtasia/TechSmithCamtasia.munki.recipe
@@ -56,7 +56,7 @@ if [ -n "$regkey" ]; then
 	/bin/chmod a+x /Users/Shared/TechSmith/Camtasia/Camtasia\ Registration\ Key
 fi
 
-ver=$(defaults read /Applications/Camtasia 2.app/Contents/Info.plist CFBundleShortVersionString)
+ver=$(defaults read /Applications/Camtasia\ 2.app/Contents/Info.plist CFBundleShortVersionString)
 
 for USER_TEMPLATE in $(/bin/ls /System/Library/User\ Template)
 do


### PR DESCRIPTION
The missing \ before the space results in the error:

The domain/default pair of (/Applications/Camtasia, 2.app/Contents/Info.plist) does not exist

being printed out when installing the application.  This results in the settings that rely on "ver" not being setup properly upon installation.
