### PR TITLE
Updated so TechSmithSnagit recipe is not version specific

### DIFF
--- a/TechSmithSnagit/TechSmithSnagit.pkg.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.pkg.recipe
@@ -57,9 +57,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/Snagit.app</string>
+                <string>%pathname%/%app_name%</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/Snagit.app</string>
+                <string>%pkgroot%/Applications/%app_name%</string>
             </dict>
         </dict>
         <dict>
@@ -74,7 +74,7 @@
                     <key>pkgdir</key>
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
-                    <string>com.techsmith.snagit4.pkg</string>
+                    <string>%bundleid%</string>
                     <key>options</key>
                     <string>purge_ds_store</string>
                     <key>scripts</key>


### PR DESCRIPTION
Updated so recipe is not version specific
+ Updated to use %app_name% for the source_path and destination_path keys in the Copier Processor.
+ Updated to use %bundleid% in the PkgCreator Processor.