### PR TITLE
Update TechSmithURLProvider to use URLGetter superclass

### DIFF
--- a/TechSmithSnagit/TechSmithURLProvider.py
+++ b/TechSmithSnagit/TechSmithURLProvider.py
@@ -1,16 +1,11 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
 
 import json
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib import request as urllib  # For Python 3
-except ImportError:
-    import urllib  # For Python 2
-
+from autopkglib import Processor, ProcessorError, URLGetter
 
 
 __all__ = ["TechSmithURLProvider"]
@@ -19,14 +14,20 @@ TS_BASE_URL = "https://www.techsmith.com/api/v/1/products/getallversions/%s"
 TS_VER_URL = "https://www.techsmith.com/api/v/1/products/getversioninfo/%s"
 TS_DL_URL = "http://download.techsmith.com%s%s"
 
-class TechSmithURLProvider(Processor):
+TS_PROD_CODES = {
+    "camtasia": 9,
+    "snagit": 100,
+}
+
+
+class TechSmithURLProvider(URLGetter):
     """Provides URL to the latest Techsmith product release."""
+
     description = __doc__
     input_variables = {
         "product_name": {
             "required": True,
-            "description":
-                "Product to fetch URL for. One of 'camtasia' or 'snagit'.",
+            "description": "Product to fetch URL for. One of 'camtasia' or 'snagit'.",
         },
         "base_url": {
             "required": False,
@@ -34,28 +35,35 @@ class TechSmithURLProvider(Processor):
         },
     }
     output_variables = {
-        "url": {
-            "description": "URL to the latest Techsmith product release.",
-        },
+        "url": {"description": "URL to the latest Techsmith product release.",},
     }
 
     def main(self):
         """Provide a Techsmith download URL"""
+
+        # Use provided product name to determine the product code
         product_name = self.env["product_name"]
+        if product_name not in TS_PROD_CODES.keys():
+            raise ProcessorError("Unknown product name: %s" % product_name)
+        prodcode = TS_PROD_CODES[product_name]
+
+        # Retrieve JSON file that contains version information
         base_url = self.env.get("base_url", TS_BASE_URL)
-        if product_name == "camtasia":
-            prodcode = "9"
-        elif product_name == "snagit":
-            prodcode = "100"
         url = base_url % (prodcode)
-        response = urllib.urlopen(url)
-        data = json.loads(response.read())
+        data = json.loads(self.download(url))
+
+        # Get version information for the item with the greatest VersionID
+        data = sorted(data, key=lambda x: int(x["VersionID"]), reverse=True)
         vers = "%s.%s.%s" % (data[0]["Major"], data[0]["Minor"], data[0]["Maintenance"])
         versionid = data[0]["VersionID"]
+
+        # With the latest version information, obtain the download URL
         vurl = TS_VER_URL % (versionid)
-        vresponse = urllib.urlopen(vurl)
-        vdata = json.loads(vresponse.read())
-        dlurl = TS_DL_URL % (vdata["PrimaryDownloadInformation"]["RelativePath"], vdata["PrimaryDownloadInformation"]["Name"])
+        vdata = json.loads(self.download(vurl))
+        dlurl = TS_DL_URL % (
+            vdata["PrimaryDownloadInformation"]["RelativePath"],
+            vdata["PrimaryDownloadInformation"]["Name"],
+        )
         self.env["url"] = dlurl
         self.env["version"] = vers
         self.output("Found URL %s" % self.env["url"])


### PR DESCRIPTION
[URLGetter](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors) was introduced in AutoPkg 1.4, and will make the transition to AutoPkg 2.x and Python 3.x easier. Recipe functionality is unchanged.

AutoPkg run log for reference: https://gist.github.com/homebysix/c36b5c25bb0f2e6c28c24cf80c6131ae