### PR TITLE
made CodeSignatureVerifier identifier variable

### DIFF
--- a/TechSmithCamtasia/TechSmithCamtasia.download.recipe
+++ b/TechSmithCamtasia/TechSmithCamtasia.download.recipe
@@ -36,19 +36,19 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pattern</key>
-				<string>%pathname%/*.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>FileFinder</string>
-		</dict>
+ 			<key>Arguments</key>
+ 			<dict>
+ 				<key>dmg_path</key>
+ 				<string>%pathname%</string>
+ 			</dict>
+ 			<key>Processor</key>
+ 			<string>AppDmgVersioner</string>
+ 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pathname%/%dmg_found_filename%/Contents/Info.plist</string>
+				<string>%pathname%/%app_name%/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleIdentifier</key>
@@ -66,7 +66,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%dmg_found_filename%</string>
+				<string>%pathname%/%app_name%</string>
 				<key>requirements</key>
 				<string>identifier "%cfbundleidentifier%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
 			</dict>

--- a/TechSmithCamtasia/TechSmithCamtasia.download.recipe
+++ b/TechSmithCamtasia/TechSmithCamtasia.download.recipe
@@ -12,44 +12,67 @@
 		<string>TechSmithCamtasia</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.2.5</string>
 	<key>Process</key>
 	<array>
-        <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>product_name</key>
-                <string>camtasia</string>
-            </dict>
-            <key>Processor</key>
-            <string>com.github.autopkg.kernsb.download.TechSmithSnagit/TechSmithURLProvider</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%url%</string>
-                <key>filename</key>
-                <string>%NAME%.dmg</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%/Camtasia 2019.app</string>
-                <key>requirements</key>
-                <string>identifier "com.techsmith.camtasia2019" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
-            </dict>
-        </dict>
-    </array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>product_name</key>
+				<string>camtasia</string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.autopkg.kernsb.download.TechSmithSnagit/TechSmithURLProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.dmg</string>
+				<key>url</key>
+				<string>%url%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%pathname%/*.app</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+				<string>%pathname%/%dmg_found_filename%/Contents/Info.plist</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleIdentifier</key>
+					<string>cfbundleidentifier</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/%dmg_found_filename%</string>
+				<key>requirements</key>
+				<string>identifier "%cfbundleidentifier%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/TechSmithSnagit/TechSmithSnagit.download.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.download.recipe
@@ -12,7 +12,7 @@
 		<string>TechSmithSnagit</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.2.5</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -45,6 +45,20 @@
 			<string>AppDmgVersioner</string>
 		</dict>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>info_path</key>
+				<string>%pathname%/%app_name%/Contents/Info.plist</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleIdentifier</key>
+					<string>cfbundleidentifier</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>PlistReader</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
@@ -54,7 +68,7 @@
 				<key>input_path</key>
 				<string>%pathname%/%app_name%</string>
 				<key>requirements</key>
-				<string>identifier "com.TechSmith.Snagit2020" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
+				<string>identifier "%cfbundleidentifier%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
- made `input_path` and `requirements` strings variable to account for Camtasia and Snagit changing their names and identifiers with each new major release
  - uses `AppDmgVersioner` to identify .app filename and `PlistReader` to get `CFBundleIdentifier` string, then adds that to `requirements` string as bundle identifier
  - fixes `CodeSignatureVerifier` errors reported in #23 and #24
- slight increase to `MinimumVersion` (but I'd bet these recipes require 1.0 or even newer at minimum at this point)
- ran through plist linter