### PR TITLE
Removing print()'ing of the key and path to stdout

### DIFF
--- a/TechSmithSnagit/TechSmithAddScriptKey.py
+++ b/TechSmithSnagit/TechSmithAddScriptKey.py
@@ -40,11 +40,11 @@ class TechSmithAddScriptKey(Processor):
         
         key = self.env['REG_KEY']
         
-        print(key)
+        # print(key)
         
         path = os.path.join(os.path.dirname(__file__), 'Scripts/postinstall')
         
-        print(path)
+        # print(path)
         
         if key is not None:
             


### PR DESCRIPTION
I personally see no value to have the `key` and `path` printed to standard out.  Does anyone else have a reason to do so?

If someone would like to see some verbosity, may switch print() to self.output()?  That would see more correct to me.