### PR TITLE
Updating TechSmithURLProvider Process Sorted Key

### DIFF
--- a/TechSmithSnagit/TechSmithURLProvider.py
+++ b/TechSmithSnagit/TechSmithURLProvider.py
@@ -53,7 +53,7 @@ class TechSmithURLProvider(URLGetter):
         data = json.loads(self.download(url))
 
         # Get version information for the item with the greatest VersionID
-        data = sorted(data, key=lambda x: int(x["VersionID"]), reverse=True)
+        data = sorted(data, key=lambda x: int(x["Major"]), reverse=True)
         vers = "%s.%s.%s" % (data[0]["Major"], data[0]["Minor"], data[0]["Maintenance"])
         versionid = data[0]["VersionID"]
 


### PR DESCRIPTION
Updated `sorted` `key` to use `Major` version int instead of `VersionID`.

This resolves the #33 issue where 2019.1.11 is being downloaded due to its `VersionID` being larger than all other versions.

While this fixes the issue for now, a slightly more "complex" logic may need to be introduced to sort more appropriately (if more than one major version is ever listed in the API return).