### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/TechSmithCamtasia/TechSmithCamtasia.download.recipe
+++ b/TechSmithCamtasia/TechSmithCamtasia.download.recipe
@@ -67,7 +67,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/%app_name%</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "%cfbundleidentifier%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
 			</dict>
 			<key>Processor</key>

--- a/TechSmithSnagit/TechSmithSnagit.download.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.download.recipe
@@ -67,7 +67,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/%app_name%</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "%cfbundleidentifier%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TQL462TU8"</string>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.