### PR TITLE
consolidated shared resources in TechSmithSnagit.download.recipe, removed invalid PathDeleter path from TechSmithSnagit.pkg.recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ defaults read /Users/Shared/TechSmith/Camtasia/Camtasia\ Registration\ Key\ Unif
 
 Download, JSS, Munki, and Pkg recipes for TechSmith Snagit.
 
-Munki and Pkg recipes include a preinstall script that removes an existing version prior to install, and a postinstall script that sets a number of first-run preferences. Also, the postinstall uses the optional `SNAGIT_KEY` input value to key the install with your registration key, if desired.
+The Download recipe includes a `PREINSTALL_SCRIPT` input value that removes an existing version prior to install, and a `POSTINSTALL_SCRIPT` input value to key the install with your registration key. These scripts are referenced by the Munki (both) and Pkg (preinstall only) recipes, and can be modified in an override if desired. To use the Munki, Pkg, or subsequent child recipes, a license key must be provided in an override via the `SNAGIT_KEY` input, which will license Snagit during the installation.
 
 To use `SNAGIT_KEY`, create an override and
   * For v2020 and newer:
@@ -60,7 +60,7 @@ defaults read /Users/Shared/TechSmith/Snagit/SnagitRegistrationKey.plist RegKey 
 **[Source](https://support.techsmith.com/hc/en-us/articles/115007344888-Enterprise-Install-Guidelines-for-Snagit-on-MacOS)**
 
 
-*NOTE: I previously used Munki regularly, but have recently moved to a JAMF shop. I have provided Munki recipes that I believe should work, but I do not make use of them. Munki Admins, please let me know if a Munki recipe needs adjusted!*
+*NOTE: I previously used Munki regularly, but have recently moved to a JAMF shop. I have provided Munki recipes that I believe should work, but I do not make use of them. Munki Admins, please let me know if a Munki recipe needs any adjustments!*
 
 bkerns-recipes
 --------------

--- a/TechSmithSnagit/TechSmithSnagit.download.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.download.recipe
@@ -3,18 +3,53 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest TechSmith Snagit disk image.</string>
+	<string>Downloads the latest TechSmith Snagit disk image.
+
+To use TechSmithSnagit.munki.recipe, TechSmith.pkg.recipe, or subsequent child recipes, a license key must be provided in an override via the SNAGIT_KEY input, which will license Snagit during the installation.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.kernsb.download.TechSmithSnagit</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>TechSmithSnagit</string>
+		<key>POSTINSTALL_SCRIPT</key>
+		<string>#!/bin/sh
+
+regkey="%SNAGIT_KEY%"
+
+if [ -n "$regkey" ]; then
+	[[ ! -d "/Users/Shared/TechSmith/Snagit" ]] &amp;&amp; /bin/mkdir -p "/Users/Shared/TechSmith/Snagit"
+	echo "$regkey" &gt; "/Users/Shared/TechSmith/Snagit/LicenseKey"
+	/bin/chmod -R 777 "/Users/Shared/Snagit"
+	/bin/chmod a+x "/Users/Shared/TechSmith/Snagit/LicenseKey"
+else
+	echo "Warning:  Snagit was not licensed!"
+fi
+
+exit 0</string>
+		<key>PREINSTALL_SCRIPT</key>
+		<string>#!/bin/sh
+
+echo "Deleting previous Snagit installs (if present)..."
+/usr/bin/find "/Applications" -name "Snagit*.app" -type d -maxdepth 1 -exec rm -rfv {} \;
+
+exit 0</string>
+		<key>SNAGIT_KEY</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.5</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>predicate</key>
+				<string>SNAGIT_KEY == ""</string>
+			</dict>
+			<key>Processor</key>
+			<string>StopProcessingIf</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/TechSmithSnagit/TechSmithSnagit.download.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.download.recipe
@@ -26,6 +26,61 @@ else
 	echo "Warning:  Snagit was not licensed!"
 fi
 
+ver=$(defaults read /Applications/Snagit.app/Contents/Info.plist CFBundleShortVersionString)
+
+for USER_TEMPLATE in $(/bin/ls /System/Library/User\ Template)
+do
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" DidTheOneOneRearrange -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" Ran1.1Upgrade -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" Ran3.3Upgrade -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SUEnableAutomaticChecks -bool "FALSE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SUHasLaunchedBefore -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SULastCheckTime -date "2015-01-01 12:00:00 +0000"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SUSendProfileInfo -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" autosaveFolderLocation -string "/Users/Shared/TechSmith"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" currentCaptureMode -int 5
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" defaultCollapsed -bool "FALSE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" hasLaunchedSnagitPreviously -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" lastLaunchedSnagitVersion -string "${ver}"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" lastNag -date "2015-01-01 12:00:00 +0000"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" lastUsedTool -int 2
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" newInstallSendAttempts -int 0
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" resetVideoData -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" stampSubpath -string "/Stamps.localized"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" tutorialAssetsShown -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" tutorialImageShown -bool "TRUE"
+    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" RearrangedForStepTool -bool "TRUE"
+done
+
+for USER in $(/bin/ls /Users | /usr/bin/grep -v "Shared\|\.")
+do
+    if [ ! USER = "Shared" ]; then
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" DidTheOneOneRearrange -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" Ran1.1Upgrade -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" Ran3.3Upgrade -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SUEnableAutomaticChecks -bool "FALSE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SUHasLaunchedBefore -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SULastCheckTime -date "2015-01-01 12:00:00 +0000"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SUSendProfileInfo -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" autosaveFolderLocation -string "/Users/Shared/TechSmith"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" currentCaptureMode -int 5
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" defaultCollapsed -bool "FALSE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" hasLaunchedSnagitPreviously -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" lastLaunchedSnagitVersion -string "${ver}"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" lastNag -date "2015-01-01 12:00:00 +0000"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" lastUsedTool -int 2
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" newInstallSendAttempts -int 0
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" resetVideoData -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" stampSubpath -string "/Stamps.localized"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" tutorialAssetsShown -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" tutorialImageShown -bool "TRUE"
+        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" RearrangedForStepTool -bool "TRUE"
+        owner=$(/usr/bin/stat -f &#37;Su:&#37;Sg "/Users/${USER}/Library/Preferences")
+        /usr/sbin/chown "${owner}" "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit.plist"
+        /bin/chmod 600 "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit.plist"
+    fi
+done
+
 exit 0</string>
 		<key>PREINSTALL_SCRIPT</key>
 		<string>#!/bin/sh

--- a/TechSmithSnagit/TechSmithSnagit.munki.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.munki.recipe
@@ -3,15 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of TechSmith Snagit and imports into Munki.</string>
+	<string>Downloads the current release version of TechSmith Snagit and imports into Munki.
+
+To use this recipe or subsequent child recipes, a license key must be provided in an override via the SNAGIT_KEY input, which will license Snagit during the installation.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.kernsb.munki.TechSmithSnagit</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>TechSmithSnagit</string>
-        <key>SNAGIT_KEY</key>
-        <string></string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/TechSmith</string>
 		<key>pkginfo</key>
@@ -35,84 +33,9 @@
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>preinstall_script</key>
-			<string>#!/bin/sh
-
-# Remove previous version of Snagit from /Applications
-
-if [ -d "/Applications/Snagit.app" ]; then
-   /bin/rm -rf "/Applications/Snagit.app"
-fi
-</string>
+			<string>%PREINSTALL_SCRIPT%</string>
 			<key>postinstall_script</key>
-			<string>#!/bin/sh
-
-regkey="%SNAGIT_KEY%"
-
-if [ -n "$regkey" ]; then
-	[[ ! -d /Users/Shared/TechSmith ]] &amp;&amp; /bin/mkdir /Users/Shared/TechSmith
-	[[ ! -d /Users/Shared/TechSmith/Snagit ]] &amp;&amp; /bin/mkdir /Users/Shared/TechSmith/Snagit
-	/usr/bin/defaults write /Users/Shared/TechSmith/Snagit/SnagitRegistrationKey RegKey -data "$regkey"
-	/usr/bin/plutil -convert xml1 /Users/Shared/TechSmith/Snagit/SnagitRegistrationKey.plist
-	/bin/mv /Users/Shared/TechSmith/Snagit/SnagitRegistrationKey.plist /Users/Shared/TechSmith/Snagit/SnagitRegistrationKey
-	/bin/chmod -R 777 /Users/Shared/TechSmith
-	/bin/chmod a+x /Users/Shared/TechSmith/Snagit/SnagitRegistrationKey
-fi
-
-ver=$(defaults read /Applications/Snagit.app/Contents/Info.plist CFBundleShortVersionString)
-
-for USER_TEMPLATE in $(/bin/ls /System/Library/User\ Template)
-do
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" DidTheOneOneRearrange -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" Ran1.1Upgrade -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" Ran3.3Upgrade -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SUEnableAutomaticChecks -bool "FALSE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SUHasLaunchedBefore -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SULastCheckTime -date "2015-01-01 12:00:00 +0000"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" SUSendProfileInfo -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" autosaveFolderLocation -string "/Users/Shared/TechSmith"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" currentCaptureMode -int 5
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" defaultCollapsed -bool "FALSE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" hasLaunchedSnagitPreviously -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" lastLaunchedSnagitVersion -string "${ver}"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" lastNag -date "2015-01-01 12:00:00 +0000"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" lastUsedTool -int 2
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" newInstallSendAttempts -int 0
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" resetVideoData -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" stampSubpath -string "/Stamps.localized"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" tutorialAssetsShown -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" tutorialImageShown -bool "TRUE"
-    /usr/bin/defaults write "/System/Library/User Template/${USER_TEMPLATE}/Library/Preferences/com.TechSmith.Snagit" RearrangedForStepTool -bool "TRUE"
-done
-
-for USER in $(/bin/ls /Users | /usr/bin/grep -v "Shared\|\.")
-do
-    if [ ! USER = "Shared" ]; then
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" DidTheOneOneRearrange -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" Ran1.1Upgrade -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" Ran3.3Upgrade -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SUEnableAutomaticChecks -bool "FALSE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SUHasLaunchedBefore -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SULastCheckTime -date "2015-01-01 12:00:00 +0000"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" SUSendProfileInfo -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" autosaveFolderLocation -string "/Users/Shared/TechSmith"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" currentCaptureMode -int 5
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" defaultCollapsed -bool "FALSE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" hasLaunchedSnagitPreviously -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" lastLaunchedSnagitVersion -string "${ver}"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" lastNag -date "2015-01-01 12:00:00 +0000"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" lastUsedTool -int 2
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" newInstallSendAttempts -int 0
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" resetVideoData -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" stampSubpath -string "/Stamps.localized"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" tutorialAssetsShown -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" tutorialImageShown -bool "TRUE"
-        /usr/bin/defaults write "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit" RearrangedForStepTool -bool "TRUE"
-        owner=$(/usr/bin/stat -f &#37;Su:&#37;Sg "/Users/${USER}/Library/Preferences")
-        /usr/sbin/chown "${owner}" "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit.plist"
-        /bin/chmod 600 "/Users/${USER}/Library/Preferences/com.TechSmith.Snagit.plist"
-    fi
-done
-</string>
+			<string>%POSTINSTALL_SCRIPT%</string>
 			<key>unattended_install</key>
 			<true/>
 			<key>unattended_uninstall</key>

--- a/TechSmithSnagit/TechSmithSnagit.pkg.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.pkg.recipe
@@ -39,6 +39,22 @@ This recipe requires a license key to be provided in an override via the SNAGIT_
 				<dict>
 					<key>Applications</key>
 					<string>0775</string>
+					<key>/Users</key>
+					<string>0775</string>
+					<key>/Users/Shared</key>
+					<string>0777</string>
+					<key>/Users/Shared/TechSmith</key>
+					<string>0777</string>
+					<key>/Users/Shared/TechSmith/Snagit</key>
+					<string>0777</string>
+					<key>private</key>
+					<string>0775</string>
+					<key>private/tmp</key>
+					<string>0775</string>
+					<key>private/tmp/snagit</key>
+					<string>0775</string>
+					<key>private/tmp/snagit/scripts</key>
+					<string>0775</string>
 				</dict>
 				<key>pkgroot</key>
 				<string>%RECIPE_CACHE_DIR%/pkgroot</string>
@@ -49,19 +65,8 @@ This recipe requires a license key to be provided in an override via the SNAGIT_
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgdirs</key>
-				<dict/>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/scripts</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/pkgroot/Applications/%app_name%</string>
+				<string>%pkgroot%/Applications/%app_name%</string>
 				<key>source_path</key>
 				<string>%pathname%/%app_name%</string>
 			</dict>
@@ -81,7 +86,7 @@ exit 0</string>
 				<key>file_mode</key>
 				<string>0755</string>
 				<key>file_path</key>
-				<string>%RECIPE_CACHE_DIR%/scripts/preinstall</string>
+				<string>%pkgroot%/private/tmp/snagit/scripts/preinstall</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileCreator</string>
@@ -90,24 +95,11 @@ exit 0</string>
 			<key>Arguments</key>
 			<dict>
 				<key>file_content</key>
-				<string>#!/bin/sh
-
-regkey="%SNAGIT_KEY%"
-
-if [ -n "$regkey" ]; then
-	[[ ! -d "/Users/Shared/TechSmith/Snagit" ]] &amp;&amp; /bin/mkdir -p "/Users/Shared/TechSmith/Snagit"
-	echo "$regkey" &gt; "/Users/Shared/TechSmith/Snagit/LicenseKey"
-	/bin/chmod -R 777 "/Users/Shared/Snagit"
-	/bin/chmod a+x "/Users/Shared/TechSmith/Snagit/LicenseKey"
-else
-	echo "Warning:  Snagit was not licensed!"
-fi
-
-exit 0</string>
+				<string>%SNAGIT_KEY%</string>
 				<key>file_mode</key>
-				<string>0755</string>
+				<string>0777</string>
 				<key>file_path</key>
-				<string>%RECIPE_CACHE_DIR%/scripts/postinstall</string>
+				<string>%pkgroot%/Users/Shared/TechSmith/Snagit/LicenseKey</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileCreator</string>
@@ -118,28 +110,15 @@ exit 0</string>
 				<key>pkg_request</key>
 				<dict>
 					<key>chown</key>
-					<array>
-						<dict>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-							<key>group</key>
-							<string>admin</string>
-						</dict>
-					</array>
+					<array/>
 					<key>id</key>
 					<string>%bundleid%</string>
 					<key>options</key>
 					<string>purge_ds_store</string>
-					<key>pkgdir</key>
-					<string>%RECIPE_CACHE_DIR%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-					<key>scripts</key>
-					<string>scripts</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
+					<key>scripts</key>
+					<string>%pkgroot%/private/tmp/snagit/scripts</string>
 				</dict>
 			</dict>
 			<key>Processor</key>
@@ -150,8 +129,7 @@ exit 0</string>
 			<dict>
 				<key>path_list</key>
 				<array>
-					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
-					<string>%RECIPE_CACHE_DIR%/scripts</string>
+					<string>%pkgroot%</string>
 				</array>
 			</dict>
 			<key>Processor</key>

--- a/TechSmithSnagit/TechSmithSnagit.pkg.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.pkg.recipe
@@ -7,7 +7,7 @@
 
 The installer package includes a preinstall script that will check for an existing "Snagit.app" in /Applications and remove it if found.
 
-Optionally, provide a license key to license Snagit during the installation.  If a license key is not provided, Snagit will not be licensed, but will still install.</string>
+This recipe requires a license key to be provided in an override via the SNAGIT_KEY input, which will license Snagit during the installation.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.kernsb.pkg.TechSmithSnagit</string>
 	<key>Input</key>
@@ -152,7 +152,6 @@ exit 0</string>
 				<array>
 					<string>%RECIPE_CACHE_DIR%/pkgroot</string>
 					<string>%RECIPE_CACHE_DIR%/scripts</string>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				</array>
 			</dict>
 			<key>Processor</key>

--- a/TechSmithSnagit/TechSmithSnagit.pkg.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.pkg.recipe
@@ -7,31 +7,17 @@
 
 The installer package includes a preinstall script that will check for an existing "Snagit.app" in /Applications and remove it if found.
 
-This recipe requires a license key to be provided in an override via the SNAGIT_KEY input, which will license Snagit during the installation.</string>
+To use this recipe or subsequent child recipes, a license key must be provided in an override via the SNAGIT_KEY input, which will license Snagit during the installation.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.kernsb.pkg.TechSmithSnagit</string>
 	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>TechSmithSnagit</string>
-		<key>SNAGIT_KEY</key>
-		<string></string>
-	</dict>
+	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.2.5</string>
 	<key>ParentRecipe</key>
 	<string>com.github.autopkg.kernsb.download.TechSmithSnagit</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>predicate</key>
-				<string>SNAGIT_KEY == ""</string>
-			</dict>
-			<key>Processor</key>
-			<string>StopProcessingIf</string>
-		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -77,12 +63,7 @@ This recipe requires a license key to be provided in an override via the SNAGIT_
 			<key>Arguments</key>
 			<dict>
 				<key>file_content</key>
-				<string>#!/bin/sh
-
-echo "Deleting previous Snagit installs (if present)..."
-/usr/bin/find "/Applications" -name "Snagit*.app" -type d -maxdepth 1 -exec rm -rfv {} \;
-
-exit 0</string>
+				<string>%PREINSTALL_SCRIPT%</string>
 				<key>file_mode</key>
 				<string>0755</string>
 				<key>file_path</key>


### PR DESCRIPTION
- TechSmithSnagit.download.recipe:
  - moved %SNAGIT_KEY% default value (with StopProcessingIf processor run), preinstall script, and postinstall script from TechSmithSnagit.pkg.recipe to share updated resources with TechSmithSnagit.munki.recipe (closes #40)
  - noted in Description that [license key is a required value](https://github.com/autopkg/bkerns-recipes/pull/44#issuecomment-2415124656)
- TechSmithSnagit.munki.recipe:
  - replaced scripts with %PREINSTALL_SCRIPT% and %POSTINSTALL_SCRIPT%
- TechSmithSnagit.pkg.recipe:
  - consolidated PkgRootCreator runs and added /Users/Shared/TechSmith/Snagit and /private/tmp/snagit/scripts folders
  - changed subsequent paths to use %pkgroot% variable
  - replaced postinstall script with direct write of %SNAGIT_KEY% to /Users/Shared/TechSmith/Snagit/LicenseKey with appropriate permissions
  - removed unneeded variable definitions from PkgCreator
  - removed invalid PathDeleter path (closes #46) and consolidated PathDeleter path removals based on joined resources