### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/EMCSyncplicity/EMCSyncplicity.pkg.recipe
+++ b/EMCSyncplicity/EMCSyncplicity.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.emc.syncplicity.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/EMCSyncplicitySSO/EMCSyncplicitySSO.pkg.recipe
+++ b/EMCSyncplicitySSO/EMCSyncplicitySSO.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.emc.syncplicity.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/StuffIt/StuffItExpander.pkg.recipe
+++ b/StuffIt/StuffItExpander.pkg.recipe
@@ -77,8 +77,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.techsmith.snagit.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/TechSmithCamtasia/TechSmithCamtasia.pkg.recipe
+++ b/TechSmithCamtasia/TechSmithCamtasia.pkg.recipe
@@ -75,8 +75,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.techsmith.camtasia.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>scripts</key>
                     <string>Scripts</string>
                     <key>chown</key>

--- a/TechSmithSnagit/TechSmithSnagit.pkg.recipe
+++ b/TechSmithSnagit/TechSmithSnagit.pkg.recipe
@@ -94,8 +94,6 @@ To use this recipe or subsequent child recipes, a license key must be provided i
 					<array/>
 					<key>id</key>
 					<string>%bundleid%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._